### PR TITLE
chore: release v0.1.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/*"]
 default-members = ["crates/*"]
 
 [workspace.package]
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 authors = ["Yangyang Li <yangyang.li@northwestern.edu>"]
 description = "A tool to analyze and manipulate transcript segment graph (TSG)"
@@ -33,7 +33,7 @@ tracing-subscriber = "0.3.19"
 byteorder = "1"
 zstd = "0.13"
 
-tsg-core = { version = "0.1.7", path = "crates/tsg-core" }
+tsg-core = { version = "0.1.8", path = "crates/tsg-core" }
 
 [profile.opt-dev]
 inherits = "dev"

--- a/crates/tsg-cli/CHANGELOG.md
+++ b/crates/tsg-cli/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## [Unreleased]
 
+## [0.1.8](https://github.com/TSGECO/tsg/compare/tsg-cli-v0.1.7...tsg-cli-v0.1.8)
+
+### Added
+
+
+- Enhance documentation for TSGraph to FA conversion and attribute representation - ([ce47d6b](https://github.com/TSGECO/tsg/commit/ce47d6b85a17a8b962d3787043b161a1e2b3dcbf))
+- Update summary output description and correct chain references in test data - ([0774e06](https://github.com/TSGECO/tsg/commit/0774e06ac1e578e815d674c2e357dcab28a27e3f))
+
+### Fixed
+
+
+- Update summary output formatting and correct test data entries - ([3eea99c](https://github.com/TSGECO/tsg/commit/3eea99c83989b21e4c693f7d36fc9f97f36b7680))
+
+### Other
+
+
+- Clean up whitespace and formatting in various files - ([fa803b5](https://github.com/TSGECO/tsg/commit/fa803b51b5818624bec304799998c8e8ec289bd1))
+
+
 ## [0.1.6](https://github.com/cauliyang/tsg/compare/tsg-cli-v0.1.5...tsg-cli-v0.1.6)
 
 ### Added

--- a/crates/tsg-cli/src/cli.rs
+++ b/crates/tsg-cli/src/cli.rs
@@ -41,7 +41,7 @@ pub enum Commands {
         #[arg(required = true, value_hint = ValueHint::FilePath)]
         input: PathBuf,
 
-        /// Output file path for the summary via txt format, default is stdout
+        /// Output file path for the summary, default is stdout
         #[arg(short, long, value_hint = ValueHint::FilePath)]
         output: Option<PathBuf>,
     },

--- a/crates/tsg-core/CHANGELOG.md
+++ b/crates/tsg-core/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## [Unreleased]
 
+## [0.1.8](https://github.com/TSGECO/tsg/compare/tsg-core-v0.1.7...tsg-core-v0.1.8)
+
+### Added
+
+
+- Enhance documentation for TSGraph to FA conversion and attribute representation - ([ce47d6b](https://github.com/TSGECO/tsg/commit/ce47d6b85a17a8b962d3787043b161a1e2b3dcbf))
+- Update summary output description and correct chain references in test data - ([0774e06](https://github.com/TSGECO/tsg/commit/0774e06ac1e578e815d674c2e357dcab28a27e3f))
+
+### Fixed
+
+
+- Update summary output formatting and correct test data entries - ([3eea99c](https://github.com/TSGECO/tsg/commit/3eea99c83989b21e4c693f7d36fc9f97f36b7680))
+- Correct formatting of chains in test_write.tsg - ([fd2b817](https://github.com/TSGECO/tsg/commit/fd2b817a766a09e819bf2492fea619f96a13db7c))
+
+### Other
+
+
+- Clean up whitespace and formatting in various files - ([fa803b5](https://github.com/TSGECO/tsg/commit/fa803b51b5818624bec304799998c8e8ec289bd1))
+
+
 ## [0.1.7](https://github.com/TSGECO/tsg/compare/tsg-core-v0.1.6...tsg-core-v0.1.7)
 
 ### Added

--- a/crates/tsg-core/src/graph/analysis/graph.rs
+++ b/crates/tsg-core/src/graph/analysis/graph.rs
@@ -45,7 +45,7 @@ impl TSGraphAnalysis for TSGraph {
             "bubble",
         ];
 
-        let delimiter = "\t";
+        let delimiter = ",";
         let header_str = headers.join(delimiter) + "\n";
         summary.extend_from_slice(header_str.as_bytes());
 
@@ -68,7 +68,7 @@ impl TSGraphAnalysis for TSGraph {
             use std::io::Write;
             writeln!(
                 summary,
-                "{}\t{}\t{}\t{}\t{}\t{}\t{}",
+                "{},{},{},{},{},{},{}",
                 id,
                 node_count,
                 edge_count,

--- a/crates/tsg-core/tests/data/test.gtf
+++ b/crates/tsg-core/tests/data/test.gtf
@@ -1,6 +1,6 @@
 .	tsg	transcript	.	.	.	.	.	transcript_id "b0f6cc3c26a37e1c";
-chr1	tsg	exon	1000	1200	.	+	.	exon_id "001"; expression "10.5"; ptc "10"; segment_id "001"; transcript_id "b0f6cc3c26a37e1c";
-chr1	tsg	exon	1500	1700	.	+	.	exon_id "002"; expression "10.5"; ptc "10"; segment_id "001"; transcript_id "b0f6cc3c26a37e1c";
+chr1	tsg	exon	1000	1200	.	+	.	exon_id "001"; ptc "10"; expression "10.5"; segment_id "001"; transcript_id "b0f6cc3c26a37e1c";
+chr1	tsg	exon	1500	1700	.	+	.	exon_id "002"; ptc "10"; expression "10.5"; segment_id "001"; transcript_id "b0f6cc3c26a37e1c";
 chr1	tsg	exon	2500	2700	.	+	.	exon_id "001"; segment_id "002"; transcript_id "b0f6cc3c26a37e1c";
 chr1	tsg	exon	2500	2700	.	-	.	exon_id "001"; segment_id "003"; transcript_id "b0f6cc3c26a37e1c";
 .	tsg	transcript	.	.	.	.	.	transcript_id "a00d0fe27431e9da";

--- a/crates/tsg-core/tests/data/test_write.tsg
+++ b/crates/tsg-core/tests/data/test_write.tsg
@@ -17,13 +17,13 @@ E	e2	n3	n4	chr1,chr1,1700,2000,DUP
 E	e3	n2	n3	chr1,chr1,2200,2500,TDUP
 E	e4	n3	n5	chr1,chr1,1700,2500,DUP
 # Groups
-P	transcript1	n1+ e1+ n3+ e2+ n4+
-C	chain1	n1 e1 n3 e2 n4
-U	exon_set	n1 n2 n3
-C	chain2	n2 e3 n3 e4 n5
 P	transcript2	n2+ e3+ n3+ e4+ n5+
+P	transcript1	n1+ e1+ n3+ e2+ n4+
+U	exon_set	n1 n2 n3
+C	chain1	n1 e1 n3 e2 n4
+C	chain2	n2 e3 n3 e4 n5
 # Attributes
 A	N	n1	expression:f:10.5
 A	N	n1	ptc:i:10
-A	P	transcript1	tpm:f:8.2
 A	P	transcript2	tpm:f:3.7
+A	P	transcript1	tpm:f:8.2


### PR DESCRIPTION



## 🤖 New release

* `tsg-core`: 0.1.7 -> 0.1.8
* `tsg-cli`: 0.1.7 -> 0.1.8

<details><summary><i><b>Changelog</b></i></summary><p>

## `tsg-core`

<blockquote>

## [0.1.8](https://github.com/TSGECO/tsg/compare/tsg-core-v0.1.7...tsg-core-v0.1.8)

### Added


- Enhance documentation for TSGraph to FA conversion and attribute representation - ([ce47d6b](https://github.com/TSGECO/tsg/commit/ce47d6b85a17a8b962d3787043b161a1e2b3dcbf))
- Update summary output description and correct chain references in test data - ([0774e06](https://github.com/TSGECO/tsg/commit/0774e06ac1e578e815d674c2e357dcab28a27e3f))

### Fixed


- Update summary output formatting and correct test data entries - ([3eea99c](https://github.com/TSGECO/tsg/commit/3eea99c83989b21e4c693f7d36fc9f97f36b7680))
- Correct formatting of chains in test_write.tsg - ([fd2b817](https://github.com/TSGECO/tsg/commit/fd2b817a766a09e819bf2492fea619f96a13db7c))

### Other


- Clean up whitespace and formatting in various files - ([fa803b5](https://github.com/TSGECO/tsg/commit/fa803b51b5818624bec304799998c8e8ec289bd1))
</blockquote>

## `tsg-cli`

<blockquote>

## [0.1.8](https://github.com/TSGECO/tsg/compare/tsg-cli-v0.1.7...tsg-cli-v0.1.8)

### Added


- Enhance documentation for TSGraph to FA conversion and attribute representation - ([ce47d6b](https://github.com/TSGECO/tsg/commit/ce47d6b85a17a8b962d3787043b161a1e2b3dcbf))
- Update summary output description and correct chain references in test data - ([0774e06](https://github.com/TSGECO/tsg/commit/0774e06ac1e578e815d674c2e357dcab28a27e3f))

### Fixed


- Update summary output formatting and correct test data entries - ([3eea99c](https://github.com/TSGECO/tsg/commit/3eea99c83989b21e4c693f7d36fc9f97f36b7680))

### Other


- Clean up whitespace and formatting in various files - ([fa803b5](https://github.com/TSGECO/tsg/commit/fa803b51b5818624bec304799998c8e8ec289bd1))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).